### PR TITLE
Replace default React app with portfolio website

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -8,7 +8,7 @@
   --deep-red: #b72a41;
   --malibu-sun: #fcebd8;
   --human: #ffcd9a;
-  --background-gradient: url("https://cdn.builder.io/o/assets%2F361c241d81e8477e824668352e1031fa%2F90d9edafe2cb4e0a868595e26c86ca6f?alt=media&token=76a38c9a-6367-4450-a25f-69352cc4c7d4&apiKey=361c241d81e8477e824668352e1031fa");
+  --background-gradient: url("https://cdn.builder.io/api/v1/image/assets%2F361c241d81e8477e824668352e1031fa%2F777f60b144d04ff8aba969c2fd958821?format=webp&width=800");
 }
 
 /* Reset and Base Styles */

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -39,7 +39,7 @@ body {
 
 /* Header Styles */
 .header {
-  padding: 2rem 5rem;
+  padding: 1.5rem 3rem;
   position: relative;
   z-index: 10;
 }
@@ -113,7 +113,7 @@ body {
 /* Main Layout */
 .main-layout {
   flex: 1;
-  padding: 2rem 5rem;
+  padding: 1.5rem 3rem;
   display: flex;
   justify-content: center;
 }
@@ -137,7 +137,7 @@ body {
 .profile-content {
   background: var(--light-purple);
   border-radius: 50px;
-  padding: 2.5rem 2rem 1rem;
+  padding: 2rem 1.5rem 1rem;
   opacity: 0.9;
   box-shadow: 0px 4px 0px rgba(0, 0, 0, 0.25);
   text-align: center;
@@ -223,7 +223,7 @@ body {
   border: 1.5px solid var(--light-purple);
   opacity: 0.8;
   box-shadow: 10px 10px 4px rgba(0, 0, 0, 0.25);
-  padding: 4rem 6rem;
+  padding: 2.5rem 3rem;
   min-height: 600px;
   flex: 1;
 }
@@ -398,6 +398,22 @@ body {
 
 /* Tablet styles */
 @media (max-width: 1024px) and (min-width: 769px) {
+  .header {
+    padding: 1.25rem 2rem;
+  }
+
+  .main-layout {
+    padding: 1.25rem 2rem;
+  }
+
+  .main-content {
+    padding: 2rem 2rem;
+  }
+
+  .profile-content {
+    padding: 1.75rem 1.25rem 1rem;
+  }
+
   .action-buttons {
     justify-content: center;
   }
@@ -423,7 +439,7 @@ body {
 
 @media (max-width: 768px) {
   .header {
-    padding: 1rem 1.5rem;
+    padding: 1rem 1rem;
   }
 
   .main-title {
@@ -442,11 +458,15 @@ body {
   }
 
   .main-layout {
-    padding: 1rem 1.5rem;
+    padding: 1rem 1rem;
+  }
+
+  .main-content {
+    padding: 1.5rem 1rem;
   }
 
   .profile-content {
-    padding: 2rem 1.5rem 1rem;
+    padding: 1.5rem 1rem 0.75rem;
     border-radius: 30px;
   }
 
@@ -505,7 +525,7 @@ body {
   }
 
   .footer {
-    padding: 0 1.5rem;
+    padding: 0 1rem;
   }
 }
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -119,18 +119,18 @@ body {
 }
 
 .content-wrapper {
-  display: grid;
-  grid-template-columns: 1fr 1.3fr;
+  display: flex;
   gap: 4rem;
   max-width: 1440px;
   width: 100%;
-  align-items: start;
+  align-items: center;
 }
 
 /* Profile Card Styles */
 .profile-card {
   position: relative;
   filter: drop-shadow(5px 5px 6px rgba(0, 0, 0, 0.25));
+  flex: 0 0 400px;
 }
 
 .profile-content {
@@ -224,6 +224,7 @@ body {
   box-shadow: 10px 10px 4px rgba(0, 0, 0, 0.25);
   padding: 4rem 6rem;
   min-height: 600px;
+  flex: 1;
 }
 
 .content-container {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -253,7 +253,7 @@ body {
 
 .action-buttons {
   display: flex;
-  gap: 1.5rem;
+  gap: 1rem;
   margin-bottom: 3rem;
   flex-wrap: wrap;
   justify-content: flex-start;
@@ -261,7 +261,7 @@ body {
 }
 
 .action-btn {
-  padding: 0.5rem 1.5rem;
+  padding: 0.4rem 1.2rem;
   border-radius: 45px;
   border: 1px solid var(--deep-red);
   background: var(--malibu-sun);
@@ -272,13 +272,13 @@ body {
     Roboto,
     Helvetica,
     sans-serif;
-  font-size: 1.25rem;
+  font-size: 1rem;
   font-weight: 700;
   cursor: pointer;
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
   transition: all 0.3s ease;
   opacity: 0.9;
-  min-width: 133px;
+  min-width: 110px;
 }
 
 .action-btn:hover {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -396,6 +396,13 @@ body {
   }
 }
 
+/* Tablet styles */
+@media (max-width: 1024px) and (min-width: 769px) {
+  .action-buttons {
+    justify-content: center;
+  }
+}
+
 @media (max-width: 768px) {
   .header {
     padding: 1rem 1.5rem;
@@ -452,6 +459,7 @@ body {
 
   .action-buttons {
     gap: 1rem;
+    justify-content: center;
   }
 
   .action-btn {
@@ -493,13 +501,7 @@ body {
   }
 
   .action-buttons {
-    flex-direction: column;
-    align-items: center;
-  }
-
-  .action-btn {
-    width: 100%;
-    max-width: 200px;
+    display: none;
   }
 
   .contact-info {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,42 +1,505 @@
-#root {
-  max-width: 1280px;
+/* CSS Variables */
+:root {
+  --light-purple: #f2e0f7;
+  --medium-dark-blue: #003c6c;
+  --light-blue: #c2dcf1;
+  --medium-blue: #0069be;
+  --medium-pink: #ff6e78;
+  --deep-red: #b72a41;
+  --malibu-sun: #fcebd8;
+  --human: #ffcd9a;
+  --background-gradient: url("https://cdn.builder.io/api/v1/image/assets/TEMP/f3f932850651e31ba5bc40fecc98939b2d590d90?width=2880");
+}
+
+/* Reset and Base Styles */
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family:
+    "Outfit",
+    -apple-system,
+    Roboto,
+    Helvetica,
+    sans-serif;
+  background: var(--background-gradient) lightgray 50% / cover no-repeat;
+  background-attachment: fixed;
+  min-height: 100vh;
+  color: var(--medium-dark-blue);
+}
+
+.app {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Header Styles */
+.header {
+  padding: 2rem 5rem;
+  position: relative;
+  z-index: 10;
+}
+
+.header-content {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  max-width: 1440px;
   margin: 0 auto;
-  padding: 2rem;
+  gap: 3rem;
+}
+
+.main-title {
+  font-family:
+    "Inter",
+    -apple-system,
+    Roboto,
+    Helvetica,
+    sans-serif;
+  font-size: 1.875rem;
+  font-weight: 700;
+  background: radial-gradient(
+    61.24% 61.24% at 38.76% 50%,
+    var(--malibu-sun) 50%,
+    var(--human) 100%
+  );
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  text-shadow: 4px 4px 4px rgba(0, 0, 0, 0.25);
+  white-space: nowrap;
+}
+
+.navigation {
+  display: flex;
+  align-items: center;
+  gap: 3rem;
+  background: rgba(0, 0, 0, 0.1);
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+}
+
+.nav-link {
+  font-size: 1.25rem;
+  font-weight: 400;
+  text-decoration: none;
   text-align: center;
+  transition: all 0.3s ease;
+  background: radial-gradient(
+    50% 50% at 50% 50%,
+    var(--malibu-sun) 50%,
+    var(--human) 100%
+  );
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+.nav-link-active {
+  color: var(--human);
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 5px;
+  text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.25);
+  background: none;
+  -webkit-text-fill-color: var(--human);
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
+/* Main Layout */
+.main-layout {
+  flex: 1;
+  padding: 2rem 5rem;
+  display: flex;
+  justify-content: center;
+}
+
+.content-wrapper {
+  display: grid;
+  grid-template-columns: 1fr 1.3fr;
+  gap: 4rem;
+  max-width: 1440px;
+  width: 100%;
+  align-items: start;
+}
+
+/* Profile Card Styles */
+.profile-card {
+  position: relative;
+  filter: drop-shadow(5px 5px 6px rgba(0, 0, 0, 0.25));
+}
+
+.profile-content {
+  background: var(--light-purple);
+  border-radius: 50px;
+  padding: 2.5rem 2rem 1rem;
+  opacity: 0.9;
+  box-shadow: 0px 4px 0px rgba(0, 0, 0, 0.25);
+  text-align: center;
+  position: relative;
+  min-height: 600px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.profile-image-container {
+  margin-bottom: 2rem;
+}
+
+.profile-image {
+  width: 280px;
+  height: 240px;
+  border-radius: 50%;
+  object-fit: cover;
+  box-shadow: 4px 4px 4px rgba(0, 0, 0, 0.25);
+}
+
+.profile-name {
+  font-size: 1.75rem;
+  font-weight: 600;
+  color: var(--medium-dark-blue);
+  text-shadow: 2px 2px 2px rgba(0, 0, 0, 0.25);
+  margin-bottom: 1.5rem;
+}
+
+.profile-divider {
+  width: 150px;
+  height: 2px;
+  background: #000046;
+  box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.25);
+  margin-bottom: 1.5rem;
+}
+
+.profile-title {
+  font-size: 2rem;
+  font-weight: 600;
+  color: var(--medium-dark-blue);
+  text-shadow: 2px 2px 2px rgba(0, 0, 0, 0.25);
+  margin-bottom: 2rem;
+}
+
+.social-section {
+  margin-top: auto;
+  background: var(--light-blue);
+  border-radius: 0 0 45px 45px;
+  padding: 1rem 2rem;
+  width: calc(100% + 4rem);
+  margin-left: -2rem;
+  margin-right: -2rem;
+  margin-bottom: -1rem;
+  opacity: 0.8;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.follow-text {
+  font-size: 1.875rem;
+  font-weight: 500;
+  color: var(--medium-blue);
+  text-shadow: 2px 2px 2px rgba(0, 0, 0, 0.25);
+}
+
+.social-icon {
+  box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.25);
+  cursor: pointer;
+  transition: transform 0.3s ease;
+}
+
+.social-icon:hover {
+  transform: scale(1.1);
+}
+
+/* Main Content Styles */
+.main-content {
+  background: var(--light-blue);
+  border-radius: 10px;
+  border: 1.5px solid var(--light-purple);
+  opacity: 0.8;
+  box-shadow: 10px 10px 4px rgba(0, 0, 0, 0.25);
+  padding: 4rem 6rem;
+  min-height: 600px;
+}
+
+.content-container {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.main-heading {
+  font-size: 3.75rem;
+  font-weight: 700;
+  color: var(--deep-red);
+  text-shadow: 2px 2px 2px rgba(0, 0, 0, 0.25);
+  line-height: 1.2;
+  margin-bottom: 2rem;
+}
+
+.sub-heading {
+  font-size: 1.875rem;
+  font-weight: 400;
+  color: var(--medium-pink);
+  text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.25);
+  margin-bottom: 2rem;
+}
+
+.action-buttons {
+  display: flex;
+  gap: 1.5rem;
+  margin-bottom: 3rem;
+  flex-wrap: wrap;
+}
+
+.action-btn {
+  padding: 0.5rem 1.5rem;
+  border-radius: 45px;
+  border: 1px solid var(--deep-red);
+  background: var(--malibu-sun);
+  color: var(--deep-red);
+  font-family:
+    "Inter",
+    -apple-system,
+    Roboto,
+    Helvetica,
+    sans-serif;
+  font-size: 1.25rem;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+  transition: all 0.3s ease;
+  opacity: 0.9;
+  min-width: 133px;
+}
+
+.action-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0px 6px 8px rgba(0, 0, 0, 0.3);
+}
+
+.description {
+  color: var(--medium-pink);
+  font-size: 1.5625rem;
+  font-weight: 300;
+  line-height: 1.6;
+  text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.25);
+}
+
+.description p {
+  margin-bottom: 1.5rem;
+}
+
+/* Footer Styles */
+.footer {
+  margin-top: auto;
+  padding: 0 5rem;
+}
+
+.footer-content {
+  background: var(--deep-red);
+  border-radius: 16px 16px 0 0;
+  opacity: 0.7;
+  padding: 1.5rem 2rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  max-width: 1440px;
+  margin: 0 auto;
+}
+
+.copyright {
+  color: var(--malibu-sun);
+  font-family:
+    "Inter",
+    -apple-system,
+    Roboto,
+    Helvetica,
+    sans-serif;
+  font-size: 1.25rem;
+  font-weight: 400;
+  text-shadow: 4px 4px 4px rgba(0, 0, 0, 0.25);
+}
+
+.contact-info {
+  display: flex;
+  gap: 4rem;
+}
+
+.contact-item {
+  text-align: center;
+  color: var(--malibu-sun);
+  font-family:
+    "Inter",
+    -apple-system,
+    Roboto,
+    Helvetica,
+    sans-serif;
+  font-size: 1.25rem;
+  text-shadow: 4px 4px 4px rgba(0, 0, 0, 0.25);
+}
+
+.contact-item strong {
+  font-weight: 700;
+}
+
+/* Responsive Design */
+@media (max-width: 1200px) {
+  .header {
+    padding: 1.5rem 3rem;
   }
-  to {
-    transform: rotate(360deg);
+
+  .header-content {
+    flex-direction: column;
+    gap: 2rem;
+  }
+
+  .main-title {
+    font-size: 1.5rem;
+  }
+
+  .navigation {
+    gap: 2rem;
+  }
+
+  .nav-link {
+    font-size: 1rem;
+  }
+
+  .main-layout {
+    padding: 1.5rem 3rem;
+  }
+
+  .content-wrapper {
+    grid-template-columns: 1fr;
+    gap: 3rem;
+  }
+
+  .main-content {
+    padding: 3rem 4rem;
+  }
+
+  .main-heading {
+    font-size: 3rem;
+  }
+
+  .footer {
+    padding: 0 3rem;
   }
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
+@media (max-width: 768px) {
+  .header {
+    padding: 1rem 1.5rem;
+  }
+
+  .main-title {
+    font-size: 1.25rem;
+    text-align: center;
+  }
+
+  .navigation {
+    gap: 1rem;
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .nav-link {
+    font-size: 0.875rem;
+  }
+
+  .main-layout {
+    padding: 1rem 1.5rem;
+  }
+
+  .profile-content {
+    padding: 2rem 1.5rem 1rem;
+    border-radius: 30px;
+  }
+
+  .profile-image {
+    width: 200px;
+    height: 200px;
+  }
+
+  .profile-name {
+    font-size: 1.5rem;
+  }
+
+  .profile-title {
+    font-size: 1.5rem;
+  }
+
+  .main-content {
+    padding: 2rem 1.5rem;
+  }
+
+  .main-heading {
+    font-size: 2.5rem;
+  }
+
+  .sub-heading {
+    font-size: 1.5rem;
+  }
+
+  .action-buttons {
+    gap: 1rem;
+  }
+
+  .action-btn {
+    font-size: 1rem;
+    min-width: 120px;
+  }
+
+  .description {
+    font-size: 1.25rem;
+  }
+
+  .footer-content {
+    flex-direction: column;
+    gap: 1.5rem;
+    text-align: center;
+  }
+
+  .contact-info {
+    gap: 2rem;
+  }
+
+  .contact-item {
+    font-size: 1rem;
+  }
+
+  .footer {
+    padding: 0 1.5rem;
   }
 }
 
-.card {
-  padding: 2em;
-}
+@media (max-width: 480px) {
+  .navigation {
+    gap: 0.5rem;
+  }
 
-.read-the-docs {
-  color: #888;
+  .nav-link {
+    font-size: 0.75rem;
+    padding: 0.25rem;
+  }
+
+  .action-buttons {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .action-btn {
+    width: 100%;
+    max-width: 200px;
+  }
+
+  .contact-info {
+    flex-direction: column;
+    gap: 1rem;
+  }
 }

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -256,6 +256,8 @@ body {
   gap: 1.5rem;
   margin-bottom: 3rem;
   flex-wrap: wrap;
+  justify-content: flex-start;
+  align-items: center;
 }
 
 .action-btn {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -8,7 +8,7 @@
   --deep-red: #b72a41;
   --malibu-sun: #fcebd8;
   --human: #ffcd9a;
-  --background-gradient: url("https://cdn.builder.io/api/v1/image/assets/TEMP/f3f932850651e31ba5bc40fecc98939b2d590d90?width=2880");
+  --background-gradient: url("https://cdn.builder.io/o/assets%2F361c241d81e8477e824668352e1031fa%2F90d9edafe2cb4e0a868595e26c86ca6f?alt=media&token=76a38c9a-6367-4450-a25f-69352cc4c7d4&apiKey=361c241d81e8477e824668352e1031fa");
 }
 
 /* Reset and Base Styles */

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -235,7 +235,7 @@ body {
 }
 
 .main-heading {
-  font-size: 3.75rem;
+  font-size: 3rem;
   font-weight: 700;
   color: var(--deep-red);
   text-shadow: 2px 2px 2px rgba(0, 0, 0, 0.25);
@@ -244,7 +244,7 @@ body {
 }
 
 .sub-heading {
-  font-size: 1.875rem;
+  font-size: 1.5rem;
   font-weight: 400;
   color: var(--medium-pink);
   text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.25);
@@ -288,7 +288,7 @@ body {
 
 .description {
   color: var(--medium-pink);
-  font-size: 1.5625rem;
+  font-size: 1.25rem;
   font-weight: 300;
   line-height: 1.6;
   text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.25);
@@ -407,6 +407,18 @@ body {
     padding: 0.4rem 1.2rem;
     min-width: 110px;
   }
+
+  .main-heading {
+    font-size: 2.5rem;
+  }
+
+  .sub-heading {
+    font-size: 1.375rem;
+  }
+
+  .description {
+    font-size: 1.125rem;
+  }
 }
 
 @media (max-width: 768px) {
@@ -456,11 +468,11 @@ body {
   }
 
   .main-heading {
-    font-size: 2.5rem;
+    font-size: 2rem;
   }
 
   .sub-heading {
-    font-size: 1.5rem;
+    font-size: 1.25rem;
   }
 
   .action-buttons {
@@ -475,7 +487,7 @@ body {
   }
 
   .description {
-    font-size: 1.25rem;
+    font-size: 1rem;
   }
 
   .footer-content {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -401,6 +401,12 @@ body {
   .action-buttons {
     justify-content: center;
   }
+
+  .action-btn {
+    font-size: 1rem;
+    padding: 0.4rem 1.2rem;
+    min-width: 110px;
+  }
 }
 
 @media (max-width: 768px) {
@@ -458,13 +464,14 @@ body {
   }
 
   .action-buttons {
-    gap: 1rem;
+    gap: 0.8rem;
     justify-content: center;
   }
 
   .action-btn {
-    font-size: 1rem;
-    min-width: 120px;
+    font-size: 0.875rem;
+    padding: 0.375rem 1rem;
+    min-width: 100px;
   }
 
   .description {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -123,7 +123,8 @@ body {
   gap: 4rem;
   max-width: 1440px;
   width: 100%;
-  align-items: center;
+  align-items: flex-start;
+  justify-content: center;
 }
 
 /* Profile Card Styles */

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,35 +1,20 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import React from "react";
+import { Header, ProfileCard, MainContent, Footer } from "./components";
+import "./App.css";
 
 function App() {
-  const [count, setCount] = useState(0)
-
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+    <div className="app">
+      <Header />
+      <main className="main-layout">
+        <div className="content-wrapper">
+          <ProfileCard />
+          <MainContent />
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
 }
 
-export default App
+export default App;

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+const Footer: React.FC = () => {
+  return (
+    <footer className="footer">
+      <div className="footer-content">
+        <div className="copyright">
+          <p>© 2025 by Yee Teing Lo</p>
+        </div>
+        <div className="contact-info">
+          <div className="contact-item">
+            <p>
+              <strong>CALL</strong>
+              <br />
+              +1 (647) 882 6933
+            </p>
+          </div>
+          <div className="contact-item">
+            <p>
+              <strong>E-MAIL</strong>
+              <br />
+              loyeeteing@gmail.com
+            </p>
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+};
+
+export default Footer;

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+const Header: React.FC = () => {
+  return (
+    <header className="header">
+      <div className="header-content">
+        <div className="logo-section">
+          <h1 className="main-title">YEE TEING LO / Software Developer</h1>
+        </div>
+        <nav className="navigation">
+          <a href="#about" className="nav-link nav-link-active">
+            ABOUT ME
+          </a>
+          <a href="#resume" className="nav-link">
+            RESUME
+          </a>
+          <a href="#projects" className="nav-link">
+            PROJECTS
+          </a>
+          <a href="#hobbies" className="nav-link">
+            HOBBIES
+          </a>
+          <a href="#contact" className="nav-link">
+            CONTACT
+          </a>
+        </nav>
+      </div>
+    </header>
+  );
+};
+
+export default Header;

--- a/frontend/src/components/MainContent.tsx
+++ b/frontend/src/components/MainContent.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+
+const MainContent: React.FC = () => {
+  return (
+    <div className="main-content">
+      <div className="content-container">
+        <h1 className="main-heading">HELLO EVERYONE</h1>
+        <p className="sub-heading">Here's Who I am & What I do.</p>
+
+        <div className="action-buttons">
+          <button className="action-btn">RESUME</button>
+          <button className="action-btn">PROJECTS</button>
+          <button className="action-btn">HOBBIES</button>
+        </div>
+
+        <div className="description">
+          <p>
+            The About Me or Profile section of your portfolio, is a short
+            summary about yourself in relation to the type of role you are
+            applying for. In the sample portfolio, the student has highlighted
+            their program, the projects they've worked on and their specific
+            area of interest in their field.
+          </p>
+          <p>
+            I'm a great place for you to tell a story and let your users know a
+            little more about you.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MainContent;

--- a/frontend/src/components/ProfileCard.tsx
+++ b/frontend/src/components/ProfileCard.tsx
@@ -6,7 +6,7 @@ const ProfileCard: React.FC = () => {
       <div className="profile-content">
         <div className="profile-image-container">
           <img
-            src="https://cdn.builder.io/api/v1/image/assets%2F361c241d81e8477e824668352e1031fa%2F6f9eb72f7d2147c793d1c9218249d635?format=webp&width=800"
+            src="https://cdn.builder.io/api/v1/image/assets%2F361c241d81e8477e824668352e1031fa%2F16b644c10fda4af4adab66179879caa1"
             alt="Yee Teing Lo"
             className="profile-image"
           />

--- a/frontend/src/components/ProfileCard.tsx
+++ b/frontend/src/components/ProfileCard.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+
+const ProfileCard: React.FC = () => {
+  return (
+    <div className="profile-card">
+      <div className="profile-content">
+        <div className="profile-image-container">
+          <img
+            src="https://cdn.builder.io/api/v1/image/assets%2F361c241d81e8477e824668352e1031fa%2F6f9eb72f7d2147c793d1c9218249d635?format=webp&width=800"
+            alt="Yee Teing Lo"
+            className="profile-image"
+          />
+        </div>
+        <h2 className="profile-name">Yee Teing Lo</h2>
+        <div className="profile-divider"></div>
+        <h3 className="profile-title">Software Developer</h3>
+        <div className="social-section">
+          <p className="follow-text">Follow On</p>
+          <div className="social-icon">
+            <svg width="34" height="30" viewBox="0 0 34 30" fill="none">
+              <path
+                d="M21.75 29.1667H12.25C4.33334 29.1667 1.16667 26.3333 1.16667 19.25V10.75C1.16667 3.66666 4.33334 0.833328 12.25 0.833328H21.75C29.6667 0.833328 32.8333 3.66666 32.8333 10.75V19.25C32.8333 26.3333 29.6667 29.1667 21.75 29.1667Z"
+                stroke="#0069BE"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M13.3333 7.55666C14.6594 7.55666 15.9312 8.15377 16.8689 9.21663C17.8066 10.2795 18.3333 11.721 18.3333 13.2242V19.8362H15V13.2242C15 12.7231 14.8244 12.2426 14.5118 11.8883C14.1993 11.534 13.7754 11.335 13.3333 11.335C12.8913 11.335 12.4674 11.534 12.1548 11.8883C11.8423 12.2426 11.6667 12.7231 11.6667 13.2242V19.8362H8.33334V13.2242C8.33334 11.721 8.86012 10.2795 9.7978 9.21663C10.7355 8.15377 12.0073 7.55666 13.3333 7.55666Z"
+                stroke="#006BC1"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M5.00001 8.50124H1.66667V19.8362H5.00001V8.50124Z"
+                stroke="#006BC1"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M3.33334 5.66749C4.25381 5.66749 5.00001 4.82168 5.00001 3.77833C5.00001 2.73497 4.25381 1.88916 3.33334 1.88916C2.41286 1.88916 1.66667 2.73497 1.66667 3.77833C1.66667 4.82168 2.41286 5.66749 3.33334 5.66749Z"
+                stroke="#006BC1"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ProfileCard;

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -1,0 +1,4 @@
+export { default as Header } from "./Header";
+export { default as ProfileCard } from "./ProfileCard";
+export { default as MainContent } from "./MainContent";
+export { default as Footer } from "./Footer";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "code",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
This commit completely replaces the default React application with a custom portfolio website for Yee Teing Lo.

Changes include:
- Replaced App.css with comprehensive styling including CSS variables, responsive design, and custom component styles
- Updated App.tsx to render Header, ProfileCard, MainContent, and Footer components instead of default React content
- Added new component files:
  - Header.tsx: Navigation header with title and menu links
  - ProfileCard.tsx: Profile section with image, name, title, and social links
  - MainContent.tsx: Main content area with heading, description, and action buttons
  - Footer.tsx: Footer with copyright and contact information
  - index.ts: Component exports barrel file
- Added package-lock.json file

The new design features a purple and blue color scheme with gradient backgrounds, responsive layout, and professional portfolio styling.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/9836331f759246c69efa0643b3fce30b/flare-lab)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9836331f759246c69efa0643b3fce30b</projectId>-->
<!--<branchName>flare-lab</branchName>-->